### PR TITLE
Drivername for postgresql (database utils)

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -359,7 +359,7 @@ def database_exists(url):
 
     url = copy(make_url(url))
     database = url.database
-    if url.drivername.startswith('postgresql'):
+    if url.drivername.startswith('postgres'):
         url.database = 'template1'
     else:
         url.database = None
@@ -416,7 +416,7 @@ def create_database(url, encoding='utf8', template=None):
 
     database = url.database
 
-    if url.drivername.startswith('postgresql'):
+    if url.drivername.startswith('postgres'):
         url.database = 'template1'
     elif not url.drivername.startswith('sqlite'):
         url.database = None
@@ -472,7 +472,7 @@ def drop_database(url):
 
     database = url.database
 
-    if url.drivername.startswith('postgresql'):
+    if url.drivername.startswith('postgres'):
         url.database = 'template1'
     elif not url.drivername.startswith('sqlite'):
         url.database = None


### PR DESCRIPTION
Hi,
Thanks for these useful utils. I faced a problem when checking for a db(running on linux against postgresql with python 2.7)
Problem is : as `url.database` is set to `None`, `engine.execute` will try to run using a db name which is set as same value of username, and because of this exception raises.
Solution is: Driver name on linux is set as `postgres` (not `postgresql`) and should be replaced like:

``` py
if url.drivername.startswith('postgres'):
```

Regards
